### PR TITLE
hotfix: Searcher multiple lines

### DIFF
--- a/app/src/main/java/es/dpr/marvelsampleapp/designsystem/character/Searcher.kt
+++ b/app/src/main/java/es/dpr/marvelsampleapp/designsystem/character/Searcher.kt
@@ -45,6 +45,7 @@ fun CharacterSearcher(
                     }
                 )
             },
+            singleLine = true,
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(10.dp)

--- a/app/src/main/java/es/dpr/marvelsampleapp/ui/screens/character/list/CharacterListScreen.kt
+++ b/app/src/main/java/es/dpr/marvelsampleapp/ui/screens/character/list/CharacterListScreen.kt
@@ -133,7 +133,7 @@ fun CharacterListContent(
             state = lazyState,
             modifier = Modifier
                 .padding(
-                    top = 80.dp,
+                    top = 100.dp,
                     bottom = 20.dp
                 )
         ){


### PR DESCRIPTION
Limit searcher to single line and increment list padding top